### PR TITLE
Make sourcemap paths relative to package root and prefix with package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsdx",
+  "name": "@textio/tsdx",
   "version": "0.7.2",
   "author": "Jared Palmer <jared@palmer.net>",
   "description": "Zero-config TypeScript package development",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textio/tsdx",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": "Jared Palmer <jared@palmer.net>",
   "description": "Zero-config TypeScript package development",
   "license": "MIT",


### PR DESCRIPTION
This fixes an issue where all sourcemap paths are relative to the dist directory (eg '../src/foo/bar.ts'), which causes them to all point to the same (wrong) directory when bundled by a consumer's webpack https://github.com/rollup/rollup/issues/2168#issuecomment-416628432